### PR TITLE
Disable paging buttons on empty grid

### DIFF
--- a/Ext.ux.touch.grid/feature/Paging.js
+++ b/Ext.ux.touch.grid/feature/Paging.js
@@ -227,6 +227,7 @@ Ext.define('Ext.ux.touch.grid.feature.Paging', {
             store.on('load', 'handleGridPaint', me, { single : true });
             return;
         }
+        store.on('clear', 'handleGridPaint', me, { single : true });
 
         var total         = store.getTotalCount(),
             currentPage   = store.currentPage,
@@ -237,9 +238,9 @@ Ext.define('Ext.ux.touch.grid.feature.Paging', {
 
         me.setPages(pages);
 
-        backButton   .setDisabled(currentPage === 1);
-        forwardButton.setDisabled(currentPage === pages);
-        goToButton   .setDisabled(pages       === 0);
+        backButton   .setDisabled(currentPage === 1 || store.getCount() === 0);
+        forwardButton.setDisabled(currentPage === pages || store.getCount() === 0);
+        goToButton   .setDisabled(pages === 0  || store.getCount() === 0);
     },
 
     handleBackButton : function() {


### PR DESCRIPTION
Disable grid paging buttons when the grid is empty or the store is cleared calling the store.removeAll() function.
