### PR TITLE
Fix remote sorting

### DIFF
--- a/Ext.ux.touch.grid/feature/Sorter.js
+++ b/Ext.ux.touch.grid/feature/Sorter.js
@@ -68,6 +68,10 @@ Ext.define('Ext.ux.touch.grid.feature.Sorter', {
         }
 
         store.sort(dataIndex, dir === 'DESC' ? 'ASC' : 'DESC');
+        
+        if (store.getRemoteSort() === true) {
+            store.load();
+        }
 
         grid.fireEvent('sort');
     },


### PR DESCRIPTION
A fix for remote sorting.
Sencha Docs:
"If the remoteSort configuration has been set to true, you will have to manually call the load method after you sort to retrieve the sorted data from the server."

Link:
http://docs.sencha.com/touch/2-0/#!/api/Ext.data.Store-method-sort
