### PR TITLE
Persist sorting direction for the same column only

### DIFF
--- a/Ext.ux.touch.grid/feature/Sorter.js
+++ b/Ext.ux.touch.grid/feature/Sorter.js
@@ -67,7 +67,7 @@ Ext.define('Ext.ux.touch.grid.feature.Sorter', {
             dataIndex = el.getAttribute('dataindex'),
             sorters   = store.getSorters(),
             sorter    = sorters[0],
-            dir       = sorter ? sorter.getDirection() : 'ASC',
+            dir       = (sorter && (sorter.getProperty() === dataIndex)) ? sorter.getDirection() : 'DESC',
             column;
 
         for (; c < cNum; c++) {


### PR DESCRIPTION
Persist sorting direction for the same column only.
The default direction should be 'DESC' since it gets inverted when the store's sort gets called.
