### PR TITLE
Ignore hidden columns when calculating width

### DIFF
--- a/Ext.ux.touch.grid/List.js
+++ b/Ext.ux.touch.grid/List.js
@@ -118,6 +118,8 @@ Ext.define('Ext.ux.touch.grid.List', {
 
         for (; c < cNum; c++) {
             column = columns[c];
+            if (column.hidden)
+                continue;
             width  = column.width || defaults.column_width;
 
             if (!Ext.isNumber(width)) {

--- a/Ext.ux.touch.grid/List.js
+++ b/Ext.ux.touch.grid/List.js
@@ -317,6 +317,7 @@ Ext.define('Ext.ux.touch.grid.List', {
 
         column.hidden = hide;
 
+        me.setWidth(me._buildWidth());
         me.setItemTpl(null); //trigger new tpl on items and header
         me.refresh();
     },


### PR DESCRIPTION
Hey,

as mentioned in the title - the grid should ignore hidden columns when calculating the initial width. 
On the other hand, the grid should resize after toggling a column's visibility.

I needed this in a project of mine and thought it should be generally available :)
